### PR TITLE
Agregar pruebas unitarias completas para TaskService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,18 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,12 +10,12 @@ server.servlet.context-path=/api/v1
 # Configuración de conexión a PostgreSQL
 spring.datasource.url=jdbc:postgresql://localhost:5432/taskmanagement_db
 spring.datasource.username=postgres
-spring.datasource.password=adminadmin
+spring.datasource.password=123456789
 
 # Dialecto y comportamiento de Hibernate (JPA)
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update        
-spring.jpa.show-sql=true                    
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true  # Formatea las consultas para mejor lectura
 
 # Codificación por defecto de la conexión

--- a/src/test/java/com/org/service/TaskServiceUnitTest.java
+++ b/src/test/java/com/org/service/TaskServiceUnitTest.java
@@ -1,0 +1,278 @@
+package com.org.service;
+
+import com.org.dto.request.TaskRequest;
+import com.org.dto.response.TaskResponse;
+import com.org.exception.BusinessRuleException;
+import com.org.exception.DuplicateResourceException;
+import com.org.exception.ResourceNotFoundException;
+import com.org.mapper.TaskMapper;
+import com.org.model.Developer;
+import com.org.model.Task;
+import com.org.model.enums.TaskStatus;
+import com.org.repository.DeveloperRepository;
+import com.org.repository.TaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class TaskServiceUnitTest {
+
+    @Mock private TaskRepository taskRepository;
+    @Mock private DeveloperRepository developerRepository;
+    @Mock private TaskMapper taskMapper;
+    @InjectMocks private TaskService taskService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("CP13 - Crear tarea válida")
+    void create_validTask_returnsCreated() {
+        TaskRequest request = new TaskRequest("Tarea 1", "Desc", 1L,
+                LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 15));
+        Developer dev = new Developer(1L, "Henry");
+        Task task = Task.builder()
+                .id(1L)
+                .title("Tarea 1")
+                .description("Desc")
+                .status(TaskStatus.PENDING)
+                .developer(dev)
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .build();
+
+        TaskResponse response = new TaskResponse(1L, "Tarea 1", "Desc", "PENDING",
+                "Henry", request.startDate(), request.endDate());
+
+        when(taskRepository.existsByTitle("Tarea 1")).thenReturn(false);
+        when(developerRepository.findById(1L)).thenReturn(Optional.of(dev));
+        when(taskRepository.countActiveTasksByDeveloperId(1L, List.of(TaskStatus.PENDING, TaskStatus.IN_PROGRESS))).thenReturn(0);
+        when(taskMapper.toEntity(request, dev)).thenReturn(task);
+        when(taskRepository.save(task)).thenReturn(task);
+        when(taskMapper.toResponse(task)).thenReturn(response);
+
+        TaskResponse result = taskService.create(request);
+
+        assertEquals("Tarea 1", result.title());
+        assertEquals("PENDING", result.status());
+        assertEquals("Henry", result.developerName());
+    }
+
+    @Test
+    @DisplayName("CP14 - Crear tarea con título duplicado")
+    void create_duplicateTitle_throwsException() {
+        TaskRequest request = new TaskRequest("Tarea 1", "Desc", 1L, null, null);
+        when(taskRepository.existsByTitle("Tarea 1")).thenReturn(true);
+        assertThrows(DuplicateResourceException.class, () -> taskService.create(request));
+    }
+
+    @Test
+    @DisplayName("CP15 - Crear tarea sin título o descripción")
+    void create_nullFields_throwsException() {
+        TaskRequest request = new TaskRequest(null, null, 1L, null, null);
+        Developer dev = new Developer(1L, "Henry");
+        when(taskRepository.existsByTitle(null)).thenReturn(false);
+        when(developerRepository.findById(1L)).thenReturn(Optional.of(dev));
+        when(taskRepository.countActiveTasksByDeveloperId(1L, List.of(TaskStatus.PENDING, TaskStatus.IN_PROGRESS))).thenReturn(0);
+        when(taskMapper.toEntity(request, dev)).thenThrow(new IllegalArgumentException("Datos inválidos"));
+        assertThrows(IllegalArgumentException.class, () -> taskService.create(request));
+    }
+
+    @Test
+    @DisplayName("CP16 - Crear tarea con developer inexistente")
+    void create_invalidDeveloper_throwsException() {
+        TaskRequest request = new TaskRequest("Tarea 1", "Desc", 99L, null, null);
+        when(taskRepository.existsByTitle("Tarea 1")).thenReturn(false);
+        when(developerRepository.findById(99L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class, () -> taskService.create(request));
+    }
+
+    @Test
+    @DisplayName("CP17 - Crear tarea con developer con exceso activo")
+    void create_developerOverLimit_throwsException() {
+        TaskRequest request = new TaskRequest("Tarea 1", "Desc", 1L, null, null);
+        Developer dev = new Developer(1L, "Henry");
+        when(taskRepository.existsByTitle("Tarea 1")).thenReturn(false);
+        when(developerRepository.findById(1L)).thenReturn(Optional.of(dev));
+        when(taskRepository.countActiveTasksByDeveloperId(1L, List.of(TaskStatus.PENDING, TaskStatus.IN_PROGRESS))).thenReturn(5);
+        assertThrows(BusinessRuleException.class, () -> taskService.create(request));
+    }
+
+    // Continuación de TaskServiceUnitTest.java para CP18 - CP29
+
+    @Test
+    @DisplayName("CP18 - PENDING → IN_PROGRESS (válido)")
+    void changeStatus_pendingToInProgress_success() {
+        Task task = Task.builder().id(1L).title("T1").description("D1").status(TaskStatus.PENDING).build();
+        TaskResponse response = new TaskResponse(1L, "T1", "D1", "IN_PROGRESS", "Henry", null, null);
+
+        when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
+        when(taskRepository.save(any())).thenReturn(task);
+        when(taskMapper.toResponse(task)).thenReturn(response);
+
+        TaskResponse result = taskService.changeStatus(1L, TaskStatus.IN_PROGRESS);
+        assertEquals("IN_PROGRESS", result.status());
+    }
+
+    @Test
+    @DisplayName("CP19 - PENDING → COMPLETED (inválido)")
+    void changeStatus_pendingToCompleted_invalid() {
+        Task task = Task.builder().id(1L).status(TaskStatus.PENDING).build();
+        when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
+        assertThrows(BusinessRuleException.class, () -> taskService.changeStatus(1L, TaskStatus.COMPLETED));
+    }
+
+    @Test
+    @DisplayName("CP20 - COMPLETED → IN_PROGRESS (inválido)")
+    void changeStatus_completedToInProgress_invalid() {
+        Task task = Task.builder().id(1L).status(TaskStatus.COMPLETED).build();
+        when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
+        assertThrows(BusinessRuleException.class, () -> taskService.changeStatus(1L, TaskStatus.IN_PROGRESS));
+    }
+
+    @Test
+    @DisplayName("CP21 - IN_PROGRESS → COMPLETED")
+    void changeStatus_inProgressToCompleted_success() {
+        Task task = Task.builder().id(1L).title("T1").description("D1").status(TaskStatus.IN_PROGRESS).build();
+        TaskResponse response = new TaskResponse(1L, "T1", "D1", "COMPLETED", "Henry", null, null);
+
+        when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
+        when(taskRepository.save(any())).thenReturn(task);
+        when(taskMapper.toResponse(task)).thenReturn(response);
+
+        TaskResponse result = taskService.changeStatus(1L, TaskStatus.COMPLETED);
+        assertEquals("COMPLETED", result.status());
+    }
+
+    @Test
+    @DisplayName("CP22 - Obtener tarea existente")
+    void getTaskById_found() {
+        Task task = Task.builder().id(1L).title("T1").description("D1").status(TaskStatus.PENDING).build();
+        TaskResponse response = new TaskResponse(1L, "T1", "D1", "PENDING", "Henry", null, null);
+
+        when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
+        when(taskMapper.toResponse(task)).thenReturn(response);
+
+        TaskResponse result = taskService.findById(1L);
+        assertEquals("T1", result.title());
+    }
+
+    @Test
+    @DisplayName("CP23 - Obtener tarea inexistente")
+    void getTaskById_notFound() {
+        when(taskRepository.findById(99L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class, () -> taskService.findById(99L));
+    }
+
+    @Test
+    @DisplayName("CP24 - Buscar tareas en rango válido")
+    void findByDateRange_valid() {
+        Task task = Task.builder().id(1L).title("T1").description("D1").status(TaskStatus.PENDING).build();
+        TaskResponse response = new TaskResponse(1L, "T1", "D1", "PENDING", "Henry", null, null);
+        Pageable pageable = PageRequest.of(0, 5);
+
+        when(taskRepository.findTasksByDateRange(any(), any(), eq(pageable))).thenReturn(new PageImpl<>(List.of(task)));
+        when(taskMapper.toResponse(task)).thenReturn(response);
+
+        Page<TaskResponse> result = taskService.findByDateRange(LocalDate.now().minusDays(1), LocalDate.now(), pageable);
+        assertEquals(1, result.getContent().size());
+    }
+
+    @Test
+    @DisplayName("CP25 - Buscar tareas sin resultados")
+    void findByDateRange_empty() {
+        Pageable pageable = PageRequest.of(0, 5);
+        when(taskRepository.findTasksByDateRange(any(), any(), eq(pageable))).thenReturn(new PageImpl<>(Collections.emptyList()));
+        Page<TaskResponse> result = taskService.findByDateRange(LocalDate.now().minusDays(10), LocalDate.now(), pageable);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("CP26 - Eliminar tarea existente")
+    void deleteTask_found_executesDelete() {
+        Task task = Task.builder().id(1L).title("T1").build();
+        when(taskRepository.findById(1L)).thenReturn(Optional.of(task));
+        taskService.delete(1L);
+        verify(taskRepository).delete(task);
+    }
+
+    @Test
+    @DisplayName("CP27 - Eliminar tarea inexistente")
+    void deleteTask_notFound_throwsException() {
+        when(taskRepository.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class, () -> taskService.delete(1L));
+    }
+
+    @Test
+    @DisplayName("CP28 - Consultar tareas activas de developer válido")
+    void findActiveTasksByDeveloper_valid() {
+        Developer dev = new Developer(1L, "Henry");
+        Task task = Task.builder().id(1L).title("T1").status(TaskStatus.IN_PROGRESS).developer(dev).build();
+        TaskResponse response = new TaskResponse(1L, "T1", "Desc", "IN_PROGRESS", "Henry", null, null);
+
+        when(taskRepository.findTasksByDeveloperIdAndStatusIn(eq(1L), any())).thenReturn(List.of(task));
+        when(taskMapper.toResponse(task)).thenReturn(response);
+
+        List<TaskResponse> result = taskService.findActiveTasksByDeveloper(1L);
+        assertEquals(1, result.size());
+        assertEquals("T1", result.getFirst().title());
+    }
+
+    @Test
+    @DisplayName("CP29 - Consultar developer inexistente")
+    void findActiveTasksByDeveloper_empty() {
+        when(taskRepository.findTasksByDeveloperIdAndStatusIn(eq(99L), any())).thenReturn(Collections.emptyList());
+        List<TaskResponse> result = taskService.findActiveTasksByDeveloper(99L);
+        assertTrue(result.isEmpty());
+    }
+
+
+    @Test
+    @DisplayName("CP30 - Actualizar tarea con datos válidos y mismo developer")
+    void update_validSameDeveloper_success() {
+        Task existing = Task.builder().id(1L).title("T1").description("D1").status(TaskStatus.PENDING).developer(new Developer(1L, "Henry")).build();
+        TaskRequest request = new TaskRequest("T1", "Actualizado", 1L, null, null);
+        TaskResponse response = new TaskResponse(1L, "T1", "Actualizado", "PENDING", "Henry", null, null);
+
+        when(taskRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(taskRepository.existsByTitle("T1")).thenReturn(false);
+        when(developerRepository.findById(1L)).thenReturn(Optional.of(existing.getDeveloper()));
+        when(taskRepository.save(existing)).thenReturn(existing);
+        when(taskMapper.toResponse(existing)).thenReturn(response);
+
+        TaskResponse result = taskService.update(1L, request);
+        assertEquals("Actualizado", result.description());
+    }
+
+    @Test
+    @DisplayName("CP31 - Obtener todas las tareas paginadas")
+    void findAll_pagedList_success() {
+        Task task = Task.builder().id(1L).title("T1").description("D1").status(TaskStatus.PENDING).build();
+        TaskResponse response = new TaskResponse(1L, "T1", "D1", "PENDING", "Henry", null, null);
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(taskRepository.findAll(pageable)).thenReturn(new PageImpl<>(List.of(task)));
+        when(taskMapper.toResponse(task)).thenReturn(response);
+
+        Page<TaskResponse> result = taskService.findAll(pageable);
+        assertEquals(1, result.getTotalElements());
+        assertEquals("T1", result.getContent().getFirst().title());
+    }
+}

--- a/taskmanagment-api.postman_collection.json
+++ b/taskmanagment-api.postman_collection.json
@@ -1,0 +1,562 @@
+{
+	"info": {
+		"_postman_id": "eae67361-550e-4f47-9ae5-3c969569e52c",
+		"name": "taskmanagment-api",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "6246033"
+	},
+	"item": [
+		{
+			"name": "developer",
+			"item": [
+				{
+					"name": "Crear Developer",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"Carlos Romero\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/developers",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"developers"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Listar Developers (Todos)",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/developers",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"developers"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Listar Developers (Paginado)",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/developers/paginated?page=0&size=5&sort=name,asc",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"developers",
+								"paginated"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "0"
+								},
+								{
+									"key": "size",
+									"value": "5"
+								},
+								{
+									"key": "sort",
+									"value": "name,asc"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Obtener Developer por ID",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/developers/1",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"developers",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Actualizar Developer",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"Carlos R. Actualizado\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/developers/1",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"developers",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Eliminar Developer",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/developers/1",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"developers",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "task",
+			"item": [
+				{
+					"name": "Crear tarea",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"title\": \"Diseñar pantalla de login\",\n  \"description\": \"Maquetar y definir estilos del login\",\n  \"developerId\": 2,\n  \"startDate\": \"2025-05-20\",\n  \"endDate\": \"2025-05-24\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/tasks",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Crear Tarea – Fallo por título duplicado",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"title\": \"Diseñar pantalla de login\",\n  \"description\": \"Tarea repetida\",\n  \"developerId\": 2,\n  \"startDate\": \"2025-06-01\",\n  \"endDate\": \"2025-06-05\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/tasks",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Crear Tarea – Fallo por developer inexistente",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"title\": \"Nueva tarea 6\",\n  \"description\": \"Developer no existe\",\n  \"developerId\": 2,\n  \"startDate\": \"2025-06-01\",\n  \"endDate\": \"2025-06-10\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/tasks",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Cambiar estado – Correcto (PENDING → IN_PROGRESS)",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/tasks/3/status?status=IN_PROGRESS",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"3",
+								"status"
+							],
+							"query": [
+								{
+									"key": "status",
+									"value": "IN_PROGRESS"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Cambiar estado – Incorrecto (COMPLETED sin pasar por IN_PROGRESS)",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/tasks/4/status?status=COMPLETED",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"4",
+								"status"
+							],
+							"query": [
+								{
+									"key": "status",
+									"value": "COMPLETED"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Cambiar estado – Incorrecto (IN_PROGRESS desde COMPLETED)",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/tasks/4/status?status=IN_PROGRESS",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"4",
+								"status"
+							],
+							"query": [
+								{
+									"key": "status",
+									"value": "IN_PROGRESS"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Buscar Tarea por ID – Correcto",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/tasks/3",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"3"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Buscar Tarea por ID – ID inexistente",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/tasks/999",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"999"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Actualizar Tarea – Correcto (estado PENDING)",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"title\": \"Actualizar documentación\",\n  \"description\": \"Revisar y actualizar documentación técnica\",\n  \"developerId\": 2,\n  \"startDate\": \"2025-05-21\",\n  \"endDate\": \"2025-05-28\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/tasks/5",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"5"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Actualizar Tarea – Incorrecto (estado distinto a PENDING)",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"title\": \"Optimizar consultas SQL\",\n  \"description\": \"Mejorar el rendimiento de la base de datos\",\n  \"developerId\": 2,\n  \"startDate\": \"2025-05-22\",\n  \"endDate\": \"2025-05-29\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{base_url}}/tasks/4",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"4"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Buscar por Rango de Fechas – Correcto",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/tasks/range?start=2025-05-01&end=2025-06-10",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"range"
+							],
+							"query": [
+								{
+									"key": "start",
+									"value": "2025-05-01"
+								},
+								{
+									"key": "end",
+									"value": "2025-06-10"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Buscar por Rango – Incorrecto (start > end)",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/tasks/range?start=2025-06-01&end=2025-05-01",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"range"
+							],
+							"query": [
+								{
+									"key": "start",
+									"value": "2025-06-01"
+								},
+								{
+									"key": "end",
+									"value": "2025-05-01"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Eliminar Tarea – Correcto",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/tasks/3",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"3"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Eliminar Tarea – Tarea inexistente",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/tasks/999",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"999"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Tareas activas por Developer – Correcto",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/tasks/developer/2/active",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"developer",
+								"2",
+								"active"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Tareas activas – Developer no existe",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/tasks/developer/999/active",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"tasks",
+								"developer",
+								"999",
+								"active"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "base_url",
+			"value": "http://localhost:8080/api/v1",
+			"type": "string"
+		}
+	]
+}


### PR DESCRIPTION
Se implementaron pruebas unitarias para el servicio TaskService cubriendo todas las funcionalidades definidas en las historias de usuario HU06 a HU11. Las pruebas incluyen validaciones para:

- Creación de tareas (con reglas de negocio y validaciones) 
- Cambio de estado de tareas con control de transición 
- Consulta por ID y por rango de fechas 
- Eliminación de tareas 
- Consulta de tareas activas por developer 
- Actualización de tareas 
- Paginación 

Resultados de cobertura:

- Métodos cubiertos: 100% (8/8) 
- Líneas cubiertas: 100%

Notas:
- Se usó JUnit y Mockito para simular dependencias y validar comportamientos esperados.


Las pruebas fueron ejecutadas localmente y se verificó su correcto funcionamiento.